### PR TITLE
文件自动切割重命名，已经每日新建日志文件参数

### DIFF
--- a/glog.go
+++ b/glog.go
@@ -514,10 +514,10 @@ func (ltf *loggingTConf) DayDelivery(enable bool) *loggingTConf {
 	return ltf
 }
 
-func (ltf *loggingTConf) LogDir(path string) *loggingTConf {
-	logDir = path
-	return ltf
-}
+//func (ltf *loggingTConf) LogDir(path string) *loggingTConf {
+//	logDir = path
+//	return ltf
+//}
 
 // loggingT collects all the global state of the logging setup.
 type loggingT struct {

--- a/glog.go
+++ b/glog.go
@@ -74,6 +74,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	stdLog "log"
@@ -396,26 +397,26 @@ type flushSyncWriter interface {
 }
 
 func init() {
-	//flag.BoolVar(&logging.toStderr, "logtostderr", false, "log to standard error instead of files")
-	//flag.BoolVar(&logging.alsoToStderr, "alsologtostderr", false, "log to standard error as well as files")
-	//flag.Var(&logging.verbosity, "v", "log level for V logs")
-	//flag.Var(&logging.stderrThreshold, "stderrthreshold", "logs at or above this threshold go to stderr")
-	//flag.Var(&logging.vmodule, "vmodule", "comma-separated list of pattern=N settings for file-filtered logging")
-	//flag.Var(&logging.traceLocation, "log_backtrace_at", "when logging hits line file:N, emit a stack trace")
-	//flag.IntVar(&logging.flushInterval, "flushInterval", 1, "h Intervalog level for V logs")
-	//flag.Uint64Var(&logging.max_log_size, "max_log_size", 1, "max log size")
-	//flag.StringVar(&logging.file_name_layout, "file_name_layout", "", "file name layout")
-	//flag.BoolVar(&logging.day_delivery, "day_delivery", false, "create new file to everyday")
+	flag.BoolVar(&logging.toStderr, "logtostderr", false, "log to standard error instead of files")
+	flag.BoolVar(&logging.alsoToStderr, "alsologtostderr", false, "log to standard error as well as files")
+	flag.Var(&logging.verbosity, "v", "log level for V logs")
+	flag.Var(&logging.stderrThreshold, "stderrthreshold", "logs at or above this threshold go to stderr")
+	flag.Var(&logging.vmodule, "vmodule", "comma-separated list of pattern=N settings for file-filtered logging")
+	flag.Var(&logging.traceLocation, "log_backtrace_at", "when logging hits line file:N, emit a stack trace")
+	flag.IntVar(&logging.flushInterval, "flushInterval", 1, "h Intervalog level for V logs")
+	flag.Uint64Var(&logging.max_log_size, "max_log_size", 1, "max log size")
+	flag.StringVar(&logging.file_name_layout, "file_name_layout", "", "file name layout")
+	flag.BoolVar(&logging.day_delivery, "day_delivery", false, "create new file to everyday")
 
-	//if logging.max_log_size <= 0 {
-	//	logging.max_log_size = 100
-	//}
-	//// Default stderrThreshold is ERROR.
-	//logging.stderrThreshold = errorLog
-	//
-	//logging.setVState(0, nil, false)
-	//logging.flushInterval = 1
-	//go logging.flushDaemon()
+	if logging.max_log_size <= 0 {
+		logging.max_log_size = 100
+	}
+	// Default stderrThreshold is ERROR.
+	logging.stderrThreshold = errorLog
+
+	logging.setVState(0, nil, false)
+	logging.flushInterval = 1
+	go logging.flushDaemon()
 }
 
 // Flush flushes all pending log I/O.

--- a/glog_file.go
+++ b/glog_file.go
@@ -20,6 +20,7 @@ package glog
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"os/user"
@@ -35,12 +36,12 @@ var logDirs []string
 
 // If non-empty, overrides the choice of directory in which to write logs.
 // See createLogDirs for the full list of possible destinations.
-//var logDir = flag.String("log_dir", "", "If non-empty, write log files in this directory")
-var logDir = ""
+var logDir = flag.String("log_dir", "", "If non-empty, write log files in this directory")
+//var logDir = ""
 
 func createLogDirs() {
-	if logDir != "" {
-		logDirs = append(logDirs, logDir)
+	if *logDir != "" {
+		logDirs = append(logDirs, *logDir)
 	}
 	logDirs = append(logDirs, os.TempDir())
 }

--- a/glog_file.go
+++ b/glog_file.go
@@ -20,7 +20,6 @@ package glog
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"os"
 	"os/user"
@@ -36,11 +35,12 @@ var logDirs []string
 
 // If non-empty, overrides the choice of directory in which to write logs.
 // See createLogDirs for the full list of possible destinations.
-var logDir = flag.String("log_dir", "", "If non-empty, write log files in this directory")
+//var logDir = flag.String("log_dir", "", "If non-empty, write log files in this directory")
+var logDir = ""
 
 func createLogDirs() {
-	if *logDir != "" {
-		logDirs = append(logDirs, *logDir)
+	if logDir != "" {
+		logDirs = append(logDirs, logDir)
 	}
 	logDirs = append(logDirs, os.TempDir())
 }


### PR DESCRIPTION
1. 修复 自定义文件名后，文件大小超出后，自动切割后自定义文件名重命名
2. 添加每日新建日志文件参数 day_delivery  默认false 